### PR TITLE
fixed text disappearing when dark mode is active

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -37,7 +37,7 @@ body.dark-theme{
   background-size: cover;
   --primary-bg-color:#222;
   --primary-text-color:#fff;
-  --secondary-text-color:#fff;
+  --secondary-text-color:#222;
 }
 
 


### PR DESCRIPTION
### Description

When the dark mode is active the text on the button disappears. I fixed it by changing the value of secondary-text-color from #fff(white) to #222(black).

### Checklist

- [x] I am making a proper pull request, not spam.
- [x] I've checked the issue list before deciding what to submit.

## Related Issues or Pull Requests

#38 

## Add relevant screenshot or video (if any)
![127 0 0 1_5500_ (1)](https://user-images.githubusercontent.com/78670280/136676029-3e254427-7d9d-4929-8e06-7f3a38ab2819.png)

