### PR TITLE
fix(rotation): Fixed Image rotation

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -26,10 +26,15 @@ const gRoot = getComputedStyle(Root)
 
 var RotateDeg = parseInt(gRoot.getPropertyValue('--turn'))
 
-function rotate()
-{
-  RotateDeg = (RotateDeg+90) % 360
-  Root.style.setProperty('--turn', RotateDeg + "deg")
+function rotate() {
+    ctx.save();
+  // prep canvas for rotation
+    ctx.translate(canvas.width, 0);                   // translate to canvas center
+    ctx.rotate(Math.PI*0.5);                 // add rotation transform
+    ctx.globalCompositeOperation = "copy";   // set comp. mode to "copy"
+    ctx.drawImage(ctx.canvas,  0, 0, canvas.height, canvas.width); // draw image
+    ctx.restore();
+    //Root.style.setProperty('--turn', RotateDeg + "deg")
 }
 
 // Undo last action


### PR DESCRIPTION
### Changes
<ul>
<li> Rotation only used CSS to rotate the image visually, but on clicking the "Save Now" button it still downloaded the unrotated image, fixed this by manipulating the canvas to rotate the image in the canvas so the image is rotated truly.</li>
</ul>

### Checklist

- [x] I am making a proper pull request, not spam.
- [x] I've checked the issue list before deciding what to submit.

