### PR TITLE
Crop enhancements and better ux

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -314,6 +314,11 @@ a#save-now {
   transition: box-shadow 2s ease-in;
   border: none;
 }
+.editor > .tool > .essential-tool > .action-tool > div:hover{
+  color: black;
+  box-shadow: 0.2rem 0.2rem 0.5rem rgb(85, 83, 83);
+  transform: scale(1.1);
+}
 
 .action-tool p{
   margin-top: 15%;

--- a/js/app.js
+++ b/js/app.js
@@ -81,6 +81,8 @@ const doCrop = (initialCoords, imageData, event) => {
 
 // Crop and set the new image with mouseup
 const endCrop = (initialCoords, event) => {
+    //after crop is done revert back to original cursor
+    document.body.style.cursor = "default";
    const rect = canvas.getBoundingClientRect();
    const coords = {
       x: ((event.clientX - rect.left) / (rect.right - rect.left)) * canvas.width,
@@ -103,11 +105,15 @@ const endCrop = (initialCoords, event) => {
    ctx = canvas.getContext("2d");
 
    // setting up the cropped image
-   ctx.putImageData(croppedImage, 0, 0);
+   // to the starting position of cropped image
+   ctx.putImageData(croppedImage, initialCoords.x, initialCoords.y);
 };
 
 // Crop when mousedown
 const startCrop = (imageData, event) => {
+    //set cursor to crosshair on crop start
+    document.body.style.cursor = "crosshair";
+    
    const rect = canvas.getBoundingClientRect();
    const initialCoords = {
       x: ((event.clientX - rect.left) / (rect.right - rect.left)) * canvas.width,


### PR DESCRIPTION
### Description

Cursor turns to crosshair on crop start and back to default on crop end.
The cropped image now does not translate to (0, 0) of the canvas instead remains at the position of crop start.

### Checklist

- [ Y ] I am making a proper pull request, not spam.
- [ Y ] I've checked the issue list before deciding what to submit.

This pr is in response to [Issue 79](https://github.com/gdscjgec/Image-Editor/issues/79)